### PR TITLE
feat : JWT 기능 및 CustomFilter 구현 및  회원가입, 로그인 구현

### DIFF
--- a/threads/build.gradle
+++ b/threads/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // JWT jjwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/threads/build.gradle
+++ b/threads/build.gradle
@@ -33,6 +33,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // JWT jjwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
     // PostgresSQL
     runtimeOnly 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'

--- a/threads/src/main/java/com/imwoo/threads/config/CustomJwtFilterConfiguration.java
+++ b/threads/src/main/java/com/imwoo/threads/config/CustomJwtFilterConfiguration.java
@@ -1,0 +1,20 @@
+package com.imwoo.threads.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.imwoo.threads.filter.JwtAuthenticationFilter;
+
+@Configuration
+public class CustomJwtFilterConfiguration {
+
+	@Bean
+	public FilterRegistrationBean<JwtAuthenticationFilter> webJwtAuthenticationFilter(
+		JwtAuthenticationFilter jwtAuthenticationFilter) {
+		FilterRegistrationBean<JwtAuthenticationFilter> registrationBean = new FilterRegistrationBean<>(
+			jwtAuthenticationFilter);
+		registrationBean.setEnabled(false); // 이 설정으로 인해 CustomFilter는 ApplicationFilter에 등록되지 않습니다.
+		return registrationBean;
+	}
+}

--- a/threads/src/main/java/com/imwoo/threads/config/EncoderConfiguration.java
+++ b/threads/src/main/java/com/imwoo/threads/config/EncoderConfiguration.java
@@ -1,0 +1,15 @@
+package com.imwoo.threads.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class EncoderConfiguration {
+
+	@Bean
+	public BCryptPasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+
+	}
+}

--- a/threads/src/main/java/com/imwoo/threads/config/JwtAuthenticationFilter.java
+++ b/threads/src/main/java/com/imwoo/threads/config/JwtAuthenticationFilter.java
@@ -1,0 +1,72 @@
+package com.imwoo.threads.config;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.imwoo.threads.exception.jwt.JwtNotFoundException;
+import com.imwoo.threads.service.JwtService;
+import com.imwoo.threads.service.UserService;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+/**
+ * 요청마다 한번의 filter 적용 되도록 OncePerRequestFilter 사용
+ */
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtService jwtService;
+	private final UserService userService;
+	private final String BEARER_PREFIX = "Bearer ";
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		log.info("JwtAuthenticationFilter start");
+
+		// TODO JWT 검증
+		// Header Authorization 가져오기
+		var authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+		var securityContext = SecurityContextHolder.getContext();
+
+		// Jwt token 존재하지 않는 경우
+		if (ObjectUtils.isEmpty(authorization) || !authorization.startsWith(BEARER_PREFIX)) {
+			throw new JwtNotFoundException();
+		}
+
+		if (!ObjectUtils.isEmpty(authorization)
+			&& authorization.startsWith(BEARER_PREFIX)
+			&& securityContext.getAuthentication() == null
+		) {
+			// token 추출
+			var accessToken = authorization.substring(BEARER_PREFIX.length());
+			var username = jwtService.getUsername(accessToken);
+			var userDetails = userService.loadUserByUsername(username);
+
+			var authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null,
+				userDetails.getAuthorities());
+
+			authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+			securityContext.setAuthentication(authenticationToken);
+			SecurityContextHolder.setContext(securityContext);
+		}
+
+		filterChain.doFilter(request, response);
+
+	}
+}

--- a/threads/src/main/java/com/imwoo/threads/config/JwtExceptionFilter.java
+++ b/threads/src/main/java/com/imwoo/threads/config/JwtExceptionFilter.java
@@ -1,0 +1,51 @@
+package com.imwoo.threads.config;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		try {
+			log.info("JwtExceptionFilter start");
+			filterChain.doFilter(request, response);
+
+		} catch (JwtException e) {
+			log.info("JwtExceptionFilter start {}", e.getMessage());
+			response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			response.setCharacterEncoding("UTF-8");
+
+			var errorMap = new HashMap<String, Object>();
+			errorMap.put("status", HttpStatus.UNAUTHORIZED);
+			errorMap.put("error", e.getMessage());
+
+			ObjectMapper objectMapper = new ObjectMapper();
+			String responseJson = objectMapper.writeValueAsString(errorMap);
+
+			response.getWriter().write(responseJson);
+		} catch (Exception e) {
+			log.info("JwtExceptionFilter exception 짜자잔 {}", e.getMessage());
+		}
+
+	}
+}

--- a/threads/src/main/java/com/imwoo/threads/config/SwaggerConfiguration.java
+++ b/threads/src/main/java/com/imwoo/threads/config/SwaggerConfiguration.java
@@ -1,0 +1,30 @@
+package com.imwoo.threads.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SwaggerConfiguration {
+
+	/**
+	 * JWT 방식의 인증으로 Header Bearer Token 설정
+	 */
+	@Bean
+	public OpenAPI customOpenAPI() {
+		var apiKey = new SecurityScheme()
+			.type(SecurityScheme.Type.APIKEY)
+			.in(SecurityScheme.In.HEADER)
+			.name("Authorization");
+
+		var securityRequirement = new SecurityRequirement().addList("Json Web Token Bearer");
+
+		return new OpenAPI()
+			.components(new Components().addSecuritySchemes("Json Web Token Bearer", apiKey))
+			.addSecurityItem(securityRequirement);
+	}
+}

--- a/threads/src/main/java/com/imwoo/threads/config/WebSecurityConfiguration.java
+++ b/threads/src/main/java/com/imwoo/threads/config/WebSecurityConfiguration.java
@@ -9,12 +9,19 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebSecurityConfiguration {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final JwtExceptionFilter jwtExceptionFilter;
 
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
@@ -37,6 +44,8 @@ public class WebSecurityConfiguration {
 				(session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			// csrf 검증은 제외
 			.csrf(CsrfConfigurer::disable)
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
 			// 기본 인증 방식을 사용
 			.httpBasic(Customizer.withDefaults());
 

--- a/threads/src/main/java/com/imwoo/threads/config/WebSecurityConfiguration.java
+++ b/threads/src/main/java/com/imwoo/threads/config/WebSecurityConfiguration.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -25,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class WebSecurityConfiguration {
 
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
-	
+
 	private List<String> DEFAULT_EXCLUDE = List.of(
 		"/",
 		"favicon.ico",
@@ -58,7 +59,11 @@ public class WebSecurityConfiguration {
 	SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		// 모든 요청에 대해서 인증 처리를 진행 할 것이다.
 		http.authorizeHttpRequests((request) ->
-				request.anyRequest().authenticated()
+				request
+					.requestMatchers(HttpMethod.POST, "/api/v1/users")
+					.permitAll()
+					.anyRequest()
+					.authenticated()
 			)
 			.cors(Customizer.withDefaults())
 			// REST API 를 개발함으로 Session 관련 생성되지 않도록 처리

--- a/threads/src/main/java/com/imwoo/threads/config/WebSecurityConfiguration.java
+++ b/threads/src/main/java/com/imwoo/threads/config/WebSecurityConfiguration.java
@@ -60,7 +60,7 @@ public class WebSecurityConfiguration {
 		// 모든 요청에 대해서 인증 처리를 진행 할 것이다.
 		http.authorizeHttpRequests((request) ->
 				request
-					.requestMatchers(HttpMethod.POST, "/api/v1/users")
+					.requestMatchers(HttpMethod.POST, "/api/v1/users", "/api/v1/users/authenticate")
 					.permitAll()
 					.anyRequest()
 					.authenticated()

--- a/threads/src/main/java/com/imwoo/threads/controller/PostController.java
+++ b/threads/src/main/java/com/imwoo/threads/controller/PostController.java
@@ -12,9 +12,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.imwoo.threads.model.PostCreateRequest;
-import com.imwoo.threads.model.PostResponse;
-import com.imwoo.threads.model.PostUpdateRequest;
+import com.imwoo.threads.model.post.request.PostCreateRequest;
+import com.imwoo.threads.model.post.request.PostUpdateRequest;
+import com.imwoo.threads.model.post.response.PostResponse;
 import com.imwoo.threads.service.PostService;
 
 import lombok.RequiredArgsConstructor;

--- a/threads/src/main/java/com/imwoo/threads/controller/UserController.java
+++ b/threads/src/main/java/com/imwoo/threads/controller/UserController.java
@@ -10,6 +10,7 @@ import com.imwoo.threads.model.user.User;
 import com.imwoo.threads.model.user.request.UserSignUpRequest;
 import com.imwoo.threads.service.UserService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -20,7 +21,7 @@ public class UserController {
 	private final UserService userService;
 
 	@PostMapping
-	public ResponseEntity<User> signUp(@RequestBody UserSignUpRequest userSignUpRequest) {
+	public ResponseEntity<User> signUp(@Valid @RequestBody UserSignUpRequest userSignUpRequest) {
 		var user = userService.signUp(
 			userSignUpRequest.username(),
 			userSignUpRequest.password()

--- a/threads/src/main/java/com/imwoo/threads/controller/UserController.java
+++ b/threads/src/main/java/com/imwoo/threads/controller/UserController.java
@@ -1,0 +1,30 @@
+package com.imwoo.threads.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.imwoo.threads.model.user.User;
+import com.imwoo.threads.model.user.request.UserSignUpRequest;
+import com.imwoo.threads.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserService userService;
+
+	@PostMapping
+	public ResponseEntity<User> signUp(@RequestBody UserSignUpRequest userSignUpRequest) {
+		var user = userService.signUp(
+			userSignUpRequest.username(),
+			userSignUpRequest.password()
+		);
+		return ResponseEntity.ok(user);
+	}
+}

--- a/threads/src/main/java/com/imwoo/threads/controller/UserController.java
+++ b/threads/src/main/java/com/imwoo/threads/controller/UserController.java
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.imwoo.threads.model.user.User;
+import com.imwoo.threads.model.user.request.UserAuthenticateRequest;
 import com.imwoo.threads.model.user.request.UserSignUpRequest;
+import com.imwoo.threads.model.user.response.UserAuthenticationResponse;
 import com.imwoo.threads.service.UserService;
 
 import jakarta.validation.Valid;
@@ -27,5 +29,16 @@ public class UserController {
 			userSignUpRequest.password()
 		);
 		return ResponseEntity.ok(user);
+	}
+
+	@PostMapping("/authenticate")
+	public ResponseEntity<UserAuthenticationResponse> authenticate(
+		@Valid @RequestBody UserAuthenticateRequest userAuthenticateRequest
+	) {
+		var response = userService.authenticate(
+			userAuthenticateRequest.username(),
+			userAuthenticateRequest.password()
+		);
+		return ResponseEntity.ok(response);
 	}
 }

--- a/threads/src/main/java/com/imwoo/threads/exception/GlobalExceptionHandler.java
+++ b/threads/src/main/java/com/imwoo/threads/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.imwoo.threads.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -12,9 +13,18 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler({ClientErrorException.class})
 	public ResponseEntity<ClientErrorResponse> handleClientErrorException(ClientErrorException e) {
+		// TODO : 전체적인 모든 에러 내용은 사용자에게 보여줄 필요는 없다. 차후 제공할 정보만 형식화하여 보여주자.
 		return new ResponseEntity<>(
 			new ClientErrorResponse(e.getHttpStatus(), e.getMessage()),
 			e.getHttpStatus()
+		);
+	}
+
+	@ExceptionHandler({MethodArgumentNotValidException.class})
+	public ResponseEntity<ClientErrorResponse> handleClientErrorException(MethodArgumentNotValidException e) {
+		return new ResponseEntity<>(
+			new ClientErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage()),
+			HttpStatus.BAD_REQUEST
 		);
 	}
 

--- a/threads/src/main/java/com/imwoo/threads/exception/jwt/JwtNotFoundException.java
+++ b/threads/src/main/java/com/imwoo/threads/exception/jwt/JwtNotFoundException.java
@@ -1,0 +1,14 @@
+package com.imwoo.threads.exception.jwt;
+
+import io.jsonwebtoken.JwtException;
+
+public class JwtNotFoundException extends JwtException {
+	public JwtNotFoundException() {
+		super("JWT Not Found");
+	}
+
+	public JwtNotFoundException(String message) {
+		super(message);
+	}
+
+}

--- a/threads/src/main/java/com/imwoo/threads/exception/user/UserDuplicatedException.java
+++ b/threads/src/main/java/com/imwoo/threads/exception/user/UserDuplicatedException.java
@@ -1,0 +1,17 @@
+package com.imwoo.threads.exception.user;
+
+import org.springframework.http.HttpStatus;
+
+import com.imwoo.threads.exception.ClientErrorException;
+
+public class UserDuplicatedException extends ClientErrorException {
+
+	public UserDuplicatedException() {
+		super(HttpStatus.BAD_REQUEST, "User Already Exists");
+	}
+
+	public UserDuplicatedException(String username) {
+		super(HttpStatus.BAD_REQUEST, "User With Username " + username + " Already Exists");
+	}
+
+}

--- a/threads/src/main/java/com/imwoo/threads/exception/user/UserNotFoundException.java
+++ b/threads/src/main/java/com/imwoo/threads/exception/user/UserNotFoundException.java
@@ -1,0 +1,17 @@
+package com.imwoo.threads.exception.user;
+
+import org.springframework.http.HttpStatus;
+
+import com.imwoo.threads.exception.ClientErrorException;
+
+public class UserNotFoundException extends ClientErrorException {
+
+	public UserNotFoundException() {
+		super(HttpStatus.NOT_FOUND, "User Not Found");
+	}
+
+	public UserNotFoundException(String username) {
+		super(HttpStatus.NOT_FOUND, "User With Username " + username + " Not Found");
+	}
+
+}

--- a/threads/src/main/java/com/imwoo/threads/filter/JwtExceptionFilter.java
+++ b/threads/src/main/java/com/imwoo/threads/filter/JwtExceptionFilter.java
@@ -1,11 +1,10 @@
-package com.imwoo.threads.config;
+package com.imwoo.threads.filter;
 
 import java.io.IOException;
 import java.util.HashMap;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,22 +14,15 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
 
-@Component
-@Slf4j
 public class JwtExceptionFilter extends OncePerRequestFilter {
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
-
 		try {
-			log.info("JwtExceptionFilter start");
 			filterChain.doFilter(request, response);
-
 		} catch (JwtException e) {
-			log.info("JwtExceptionFilter start {}", e.getMessage());
 			response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 			response.setCharacterEncoding("UTF-8");
@@ -43,8 +35,6 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
 			String responseJson = objectMapper.writeValueAsString(errorMap);
 
 			response.getWriter().write(responseJson);
-		} catch (Exception e) {
-			log.info("JwtExceptionFilter exception 짜자잔 {}", e.getMessage());
 		}
 
 	}

--- a/threads/src/main/java/com/imwoo/threads/model/entity/UserEntity.java
+++ b/threads/src/main/java/com/imwoo/threads/model/entity/UserEntity.java
@@ -50,10 +50,10 @@ public class UserEntity implements UserDetails {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long userId;
 
-	@Column
+	@Column(nullable = false)
 	private String username;
 
-	@Column
+	@Column(nullable = false)
 	private String password;
 
 	@Column

--- a/threads/src/main/java/com/imwoo/threads/model/entity/UserEntity.java
+++ b/threads/src/main/java/com/imwoo/threads/model/entity/UserEntity.java
@@ -1,0 +1,134 @@
+package com.imwoo.threads.model.entity;
+
+import java.time.ZonedDateTime;
+import java.util.Collection;
+import java.util.Random;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Entity
+/**
+ * user 앞 뒤로 쌍따옴표를 붙여서 사용해야 한다.
+ * 그 이유는 postgreSQL 에서는 user 라는 예약어가 존재한다.
+ * 예약어를 사용하는 것이 아닌 user 라는 단어를 사용한다는 것은 인식하기 위해 적용
+ */
+@Table(name = "\"user\"")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+@SQLDelete(sql = "update users set deletedDateTime = CURRENT_TIMESTAMP where userId = ?")
+//@Where(clause = "deletedDateTime IS NULL")
+@SQLRestriction("deletedDateTime IS NULL")
+/**
+ * Spring Security 에서 사용자 인증에 사용되는 User 정보를 담고 있는 UserDetails 를 상속
+ * 별도의 UserDetails 를 적용하지 않으면 DaoAuthenticationProvider 에서 InMemoryUserDetailsManager 를 통해
+ * org.springframework.security.core.userdetails.user 를 가져온다.
+ * 사용자 정의된 UserDetails 를 사용할 수 있도록 userDetails 를 설정 상에서 변경 해주어야 한다.
+ */
+public class UserEntity implements UserDetails {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long userId;
+
+	@Column
+	private String username;
+
+	@Column
+	private String password;
+
+	@Column
+	private String profile;
+
+	@Column
+	private String description;
+
+	@Column(nullable = false, updatable = false)
+	@CreatedDate
+	private ZonedDateTime createdDateTime;
+
+	@Column(nullable = false)
+	@LastModifiedDate
+	private ZonedDateTime updatedDateTime;
+
+	@Column
+	private ZonedDateTime deletedDateTime;
+
+	public static UserEntity of(String username, String password) {
+		var user = new UserEntity();
+		user.setUsername(username);
+		user.setPassword(password);
+
+		// Avatar Placeholder 서비스 (https://avatar-placeholder.iran.liara.run/) 기반
+		// 랜덤한 프로필 사진 설정 (1~100)
+		user.setProfile("https://avatar-placeholder.iran.liara.run/public/" + new Random().nextInt(100));
+
+		return user;
+	}
+
+	@PrePersist
+	private void prePersist() {
+		this.createdDateTime = ZonedDateTime.now();
+		this.updatedDateTime = this.createdDateTime;
+	}
+
+	@PreUpdate
+	private void preUpdate() {
+		this.updatedDateTime = ZonedDateTime.now();
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		// TODO 사용자별 역할 구분 ( admin, user )
+		return null;
+	}
+
+	@Override
+	public String getPassword() {
+		return password;
+	}
+
+	@Override
+	public String getUsername() {
+		return username;
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return UserDetails.super.isAccountNonExpired();
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return UserDetails.super.isAccountNonLocked();
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return UserDetails.super.isCredentialsNonExpired();
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return UserDetails.super.isEnabled();
+	}
+}

--- a/threads/src/main/java/com/imwoo/threads/model/entity/UserEntity.java
+++ b/threads/src/main/java/com/imwoo/threads/model/entity/UserEntity.java
@@ -80,7 +80,7 @@ public class UserEntity implements UserDetails {
 
 		// Avatar Placeholder 서비스 (https://avatar-placeholder.iran.liara.run/) 기반
 		// 랜덤한 프로필 사진 설정 (1~100)
-		user.setProfile("https://avatar-placeholder.iran.liara.run/public/" + new Random().nextInt(100));
+		user.setProfile("https://avatar-placeholder.iran.liara.run/public/" + new Random().nextInt(100) + 1);
 
 		return user;
 	}

--- a/threads/src/main/java/com/imwoo/threads/model/post/Post.java
+++ b/threads/src/main/java/com/imwoo/threads/model/post/Post.java
@@ -1,4 +1,4 @@
-package com.imwoo.threads.model;
+package com.imwoo.threads.model.post;
 
 import java.time.ZonedDateTime;
 import java.util.Objects;

--- a/threads/src/main/java/com/imwoo/threads/model/post/request/PostCreateRequest.java
+++ b/threads/src/main/java/com/imwoo/threads/model/post/request/PostCreateRequest.java
@@ -1,4 +1,4 @@
-package com.imwoo.threads.model;
+package com.imwoo.threads.model.post.request;
 
 public record PostCreateRequest(String body) {
 }

--- a/threads/src/main/java/com/imwoo/threads/model/post/request/PostUpdateRequest.java
+++ b/threads/src/main/java/com/imwoo/threads/model/post/request/PostUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.imwoo.threads.model;
+package com.imwoo.threads.model.post.request;
 
 public record PostUpdateRequest(String body) {
 }

--- a/threads/src/main/java/com/imwoo/threads/model/post/response/PostResponse.java
+++ b/threads/src/main/java/com/imwoo/threads/model/post/response/PostResponse.java
@@ -1,4 +1,4 @@
-package com.imwoo.threads.model;
+package com.imwoo.threads.model.post.response;
 
 import java.time.ZonedDateTime;
 

--- a/threads/src/main/java/com/imwoo/threads/model/user/User.java
+++ b/threads/src/main/java/com/imwoo/threads/model/user/User.java
@@ -1,0 +1,26 @@
+package com.imwoo.threads.model.user;
+
+import java.time.ZonedDateTime;
+
+import com.imwoo.threads.model.entity.UserEntity;
+
+public record User(
+	Long userId,
+	String username,
+	String profile,
+	String description,
+	ZonedDateTime createdDateTime,
+	ZonedDateTime updatedDateTime
+) {
+
+	public static User from(UserEntity userEntity) {
+		return new User(
+			userEntity.getUserId(),
+			userEntity.getUsername(),
+			userEntity.getProfile(),
+			userEntity.getDescription(),
+			userEntity.getCreatedDateTime(),
+			userEntity.getUpdatedDateTime()
+		);
+	}
+}

--- a/threads/src/main/java/com/imwoo/threads/model/user/request/UserAuthenticateRequest.java
+++ b/threads/src/main/java/com/imwoo/threads/model/user/request/UserAuthenticateRequest.java
@@ -1,0 +1,9 @@
+package com.imwoo.threads.model.user.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record UserAuthenticateRequest(
+	@NotEmpty String username,
+	@NotEmpty String password
+) {
+}

--- a/threads/src/main/java/com/imwoo/threads/model/user/request/UserSignUpRequest.java
+++ b/threads/src/main/java/com/imwoo/threads/model/user/request/UserSignUpRequest.java
@@ -1,7 +1,9 @@
 package com.imwoo.threads.model.user.request;
 
+import jakarta.validation.constraints.NotEmpty;
+
 public record UserSignUpRequest(
-	String username,
-	String password
+	@NotEmpty String username,
+	@NotEmpty String password
 ) {
 }

--- a/threads/src/main/java/com/imwoo/threads/model/user/request/UserSignUpRequest.java
+++ b/threads/src/main/java/com/imwoo/threads/model/user/request/UserSignUpRequest.java
@@ -1,0 +1,7 @@
+package com.imwoo.threads.model.user.request;
+
+public record UserSignUpRequest(
+	String username,
+	String password
+) {
+}

--- a/threads/src/main/java/com/imwoo/threads/model/user/response/UserAuthenticationResponse.java
+++ b/threads/src/main/java/com/imwoo/threads/model/user/response/UserAuthenticationResponse.java
@@ -1,0 +1,6 @@
+package com.imwoo.threads.model.user.response;
+
+public record UserAuthenticationResponse(
+	String accessToken
+) {
+}

--- a/threads/src/main/java/com/imwoo/threads/repository/PostEntityRepository.java
+++ b/threads/src/main/java/com/imwoo/threads/repository/PostEntityRepository.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.imwoo.threads.model.PostResponse;
 import com.imwoo.threads.model.entity.PostEntity;
+import com.imwoo.threads.model.post.response.PostResponse;
 
 public interface PostEntityRepository extends JpaRepository<PostEntity, Long> {
 

--- a/threads/src/main/java/com/imwoo/threads/repository/UserEntityRepository.java
+++ b/threads/src/main/java/com/imwoo/threads/repository/UserEntityRepository.java
@@ -1,0 +1,14 @@
+package com.imwoo.threads.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.imwoo.threads.model.entity.UserEntity;
+
+@Repository
+public interface UserEntityRepository extends JpaRepository<UserEntity, Long> {
+
+	Optional<UserEntity> findByUsername(String username);
+}

--- a/threads/src/main/java/com/imwoo/threads/service/JwtService.java
+++ b/threads/src/main/java/com/imwoo/threads/service/JwtService.java
@@ -1,0 +1,55 @@
+package com.imwoo.threads.service;
+
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class JwtService {
+
+	// TODO properties 등 외부적으로 노출되지 않은 key 로 사용 및 멀티 key 사용 고민
+	private static final SecretKey key = Jwts.SIG.HS256.key().build();
+
+	public String generateAccessToken(UserDetails userDetails) {
+		return generateToken(userDetails.getUsername());
+	}
+
+	public String getUsername(String accessToken) {
+		return getSubject(accessToken);
+	}
+
+	private String generateToken(String subject) {
+		var now = new Date();
+		// 현재 시점 3시간 이후 만료
+		var exp = new Date(now.getTime() + (1000 * 60 * 60 * 3));
+		return Jwts.builder()
+			.subject(subject)
+			.signWith(key)
+			.issuedAt(now)
+			.expiration(exp)
+			.compact();
+	}
+
+	private String getSubject(String token) {
+		try {
+			return Jwts.parser()
+				.verifyWith(key)
+				.build()
+				.parseSignedClaims(token)
+				.getPayload()
+				.getSubject();
+		} catch (JwtException e) {
+			// TODO Jwt 에러 응답 추후 생성
+			log.error("JwtException : {}", e.getMessage());
+			throw e;
+		}
+	}
+}

--- a/threads/src/main/java/com/imwoo/threads/service/PostService.java
+++ b/threads/src/main/java/com/imwoo/threads/service/PostService.java
@@ -6,10 +6,10 @@ import org.springframework.stereotype.Service;
 
 import com.imwoo.threads.exception.post.PostCreatedFailureException;
 import com.imwoo.threads.exception.post.PostNotFoundException;
-import com.imwoo.threads.model.PostCreateRequest;
-import com.imwoo.threads.model.PostResponse;
-import com.imwoo.threads.model.PostUpdateRequest;
 import com.imwoo.threads.model.entity.PostEntity;
+import com.imwoo.threads.model.post.request.PostCreateRequest;
+import com.imwoo.threads.model.post.request.PostUpdateRequest;
+import com.imwoo.threads.model.post.response.PostResponse;
 import com.imwoo.threads.repository.PostEntityRepository;
 
 import lombok.RequiredArgsConstructor;

--- a/threads/src/main/java/com/imwoo/threads/service/UserService.java
+++ b/threads/src/main/java/com/imwoo/threads/service/UserService.java
@@ -1,0 +1,27 @@
+package com.imwoo.threads.service;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.imwoo.threads.exception.user.UserNotFoundException;
+import com.imwoo.threads.repository.UserEntityRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+/**
+ * InMemoryUserDetailsManager 를 대체할 UserDetailsService
+ */
+public class UserService implements UserDetailsService {
+
+	private final UserEntityRepository userEntityRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		return userEntityRepository.findByUsername(username)
+			.orElseThrow(() -> new UserNotFoundException(username));
+	}
+}

--- a/threads/src/main/java/com/imwoo/threads/service/UserService.java
+++ b/threads/src/main/java/com/imwoo/threads/service/UserService.java
@@ -3,9 +3,13 @@ package com.imwoo.threads.service;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import com.imwoo.threads.exception.user.UserDuplicatedException;
 import com.imwoo.threads.exception.user.UserNotFoundException;
+import com.imwoo.threads.model.entity.UserEntity;
+import com.imwoo.threads.model.user.User;
 import com.imwoo.threads.repository.UserEntityRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -18,10 +22,26 @@ import lombok.RequiredArgsConstructor;
 public class UserService implements UserDetailsService {
 
 	private final UserEntityRepository userEntityRepository;
+	private final BCryptPasswordEncoder passwordEncoder;
 
 	@Override
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 		return userEntityRepository.findByUsername(username)
 			.orElseThrow(() -> new UserNotFoundException(username));
 	}
+
+	public User signUp(String username, String password) {
+		userEntityRepository.findByUsername(username)
+			.ifPresent(
+				user -> {
+					throw new UserDuplicatedException(username);
+				}
+			);
+
+		var userEntity = UserEntity.of(username, passwordEncoder.encode(password));
+		userEntityRepository.save(userEntity);
+
+		return User.from(userEntity);
+	}
+
 }

--- a/threads/src/test/java/com/imwoo/threads/controller/PostControllerTest.java
+++ b/threads/src/test/java/com/imwoo/threads/controller/PostControllerTest.java
@@ -26,9 +26,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.imwoo.threads.common.context.support.annotation.WithMockAdmin;
 import com.imwoo.threads.config.TestWebSecurityConfiguration;
-import com.imwoo.threads.model.PostCreateRequest;
-import com.imwoo.threads.model.PostResponse;
-import com.imwoo.threads.model.PostUpdateRequest;
+import com.imwoo.threads.model.post.request.PostCreateRequest;
+import com.imwoo.threads.model.post.request.PostUpdateRequest;
+import com.imwoo.threads.model.post.response.PostResponse;
 import com.imwoo.threads.service.PostService;
 
 import lombok.extern.slf4j.Slf4j;

--- a/threads/src/test/java/com/imwoo/threads/model/PostTest.java
+++ b/threads/src/test/java/com/imwoo/threads/model/PostTest.java
@@ -7,6 +7,8 @@ import java.time.ZonedDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.imwoo.threads.model.post.Post;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/threads/src/test/java/com/imwoo/threads/service/PostServiceTest.java
+++ b/threads/src/test/java/com/imwoo/threads/service/PostServiceTest.java
@@ -19,10 +19,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.imwoo.threads.exception.post.PostCreatedFailureException;
 import com.imwoo.threads.exception.post.PostNotFoundException;
-import com.imwoo.threads.model.PostCreateRequest;
-import com.imwoo.threads.model.PostResponse;
-import com.imwoo.threads.model.PostUpdateRequest;
 import com.imwoo.threads.model.entity.PostEntity;
+import com.imwoo.threads.model.post.request.PostCreateRequest;
+import com.imwoo.threads.model.post.request.PostUpdateRequest;
+import com.imwoo.threads.model.post.response.PostResponse;
 import com.imwoo.threads.repository.PostEntityRepository;
 
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
# JWT 기능 구현
## Spring Security 인증 객체 Custom
### UserDetails
- UserEntity 를 기반으로 사용자 username, password 정보 제공

### UserDetailsService
- UserService 를 통해서  JPA repository 방식으로 사용자 정보 조회 및 UserDetails 생성

## JWT 라이브러리 의존성 추가
- jjwt 라이브러리 선택 ( JWT 공식 홈페이지 상에서 가장 많은 활성화로 선택 )
- JWT 단일 key 방식으로 구현 ( 차후 멀티 key 또는 순환 key 방식으로 고려 )

## JWT 검증 Filter 구현
### Custom Filter 의 경우 OncePerRequestFilter 를 상속받아 구현
  - 동일한 요청 안에서 한번의 Filter 작업만 가능하도록 해주며, 이는 객체 내에서 사용여부 값을 가지고 판단한다. 
- JwtAuthenticationFilter  ( Header JWT 정보가 존재하면 JWT 검증 시작 )
- JwtExceptionFilter ( JwtException 예외 캐치 Filter )
- Custom Filter 의 경우 Spring Security Filter Chain 에 등록
  - JwtExceptionFilter > JwtAuthenticationFilter > UsernamePasswordAuthenticationFilter 

### Custom Filter 구현 이슈
- 배경
  - JwtAuthenticationFilter 의 경우 @Component 를 통해 Bean 으로 등록 SecurityFilterChain 에 Bean 을 기반으로 등록
  - 특정 URL ( Swagger UI 등 ) 에 대해서 인증에 관해서 permitAll() 처리 선언
- 문제
  - SecurityFilterChain 을 동작하지 않을 것이라 예상 했지만 Security 를 거치게 되면서 인증 예외가 발생하여 접근이 불가함
 - 원인
   1. permitAll() 에 대한 잘못된 이해를 가지고 있었다.
      - permitAll() 을 선언하여도 SecurityFilterChain 은 거치게 되며 이때, 인증과 관련하여 permitAll() 을 보고 접근에 대해 허용만 해주는 것
   2. Spring Security Filter 의 동작 원리와 생성 방식의 이해도 부족
      - Spring 에서 Filter 는 사실상 관리 대상이 될 수 없다. 이는 Spring Boot 의 내장형 WAS 에 의해서 관리 할 수 있는 것이다.
      -  이를 가능하게 한 것은 DelegatingFilterPorxy 에 의해서 처리가 되고, 이 안에서 FilterChainProxy 가 SecurityFilterChain 을 동작하여 Spring Security 에 의해 생성된 Filter 를 차례대로 동작하게 된다.
      - [ Spring Security 아키텍처 ](https://docs.spring.io/spring-security/reference/servlet/architecture.html)
   3. CustomFilter 의 생성 시 Auto Registration
      - CustomFilter 를 @Componet 에 의해서 Bean 생성 후 Filter 를 SecurityFilterChain 에 등록 했다.
      - Spring 전체에서 ApplicationFilter( Bean 생성 시 자동 등록 ), SecurityFilterChain 2 가지에 CustomFilter 가 등록이 되었다.
      - 2개의 Filter 에 등록되면서 SecurityFilterChain 에서 특정 URL 에 대해서 Filter 자체를 제외 해도 ApplicationFilter 에 의해서 처리가 된다.
- 해결
  1. WebSecurityCustomizer 를 통해서 정말로 Security Filter 를 무시할 URL 을 별도로 등록
```java
	@Bean
	public WebSecurityCustomizer webSecurityCustomizer() {
		return (web) -> web.ignoring().requestMatchers("/swagger-ui/**");
	}
```
  2. Bean 방식으로 선언된 CustomFiler 의 ApplicationFilter 등록 제외 처리
     - FilterRegistrationBean 를 기반으로 생성된 Filter 의 설정 등을 제어
```java
	@Bean
	public FilterRegistrationBean<JwtAuthenticationFilter> webJwtAuthenticationFilter(
		JwtAuthenticationFilter jwtAuthenticationFilter) {
		FilterRegistrationBean<JwtAuthenticationFilter> registrationBean = new FilterRegistrationBean<>(
			jwtAuthenticationFilter);
		registrationBean.setEnabled(false); // 이 설정으로 인해 CustomFilter는 ApplicationFilter에 등록되지 않습니다.
		return registrationBean;
	} 
```

## 사용자 회원가입 및 로그인 기능 구현
### 회원가입
- username, password 를 기반으로 회원 가입 및 저장
- password 의 경우 BCrypt 암호화 방식으로 처리 ( 단방향 )

### 로그인
- 로그인 정보를 기반으로 인증에 사용될 AccessToken( JWT ) 발급

### Swagger ui header 추가
- 인증이 필요한 요청에 대해서 Authorization 정보를 담을 수 있도록 버튼 생성 및 Header 추가