### PR TITLE
feat : Post, User Entity 연관관계 매핑

### DIFF
--- a/threads/src/main/java/com/imwoo/threads/controller/PostController.java
+++ b/threads/src/main/java/com/imwoo/threads/controller/PostController.java
@@ -3,6 +3,7 @@ package com.imwoo.threads.controller;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.imwoo.threads.model.entity.UserEntity;
 import com.imwoo.threads.model.post.request.PostCreateRequest;
 import com.imwoo.threads.model.post.request.PostUpdateRequest;
 import com.imwoo.threads.model.post.response.PostResponse;
@@ -44,10 +46,11 @@ public class PostController {
 
 	@PostMapping
 	public ResponseEntity<PostResponse> createPost(
-		@RequestBody PostCreateRequest postCreateRequest
+		@RequestBody PostCreateRequest postCreateRequest,
+		Authentication authentication
 	) {
 		log.info("POST /api/v1/posts request body : {}", postCreateRequest);
-		var post = postService.createPost(postCreateRequest);
+		var post = postService.createPost(postCreateRequest, (UserEntity)authentication.getPrincipal());
 		return ResponseEntity.ok(post);
 	}
 

--- a/threads/src/main/java/com/imwoo/threads/controller/PostController.java
+++ b/threads/src/main/java/com/imwoo/threads/controller/PostController.java
@@ -57,19 +57,21 @@ public class PostController {
 	@PatchMapping("/{postId}")
 	public ResponseEntity<PostResponse> updatePost(
 		@PathVariable Long postId,
-		@RequestBody PostUpdateRequest postUpdateRequest
+		@RequestBody PostUpdateRequest postUpdateRequest,
+		Authentication authentication
 	) {
 		log.info("PATCH /api/v1/posts/{} request body : {}", postId, postUpdateRequest);
-		var post = postService.updatePost(postId, postUpdateRequest);
+		var post = postService.updatePost(postId, postUpdateRequest, (UserEntity)authentication.getPrincipal());
 		return ResponseEntity.ok(post);
 	}
 
 	@DeleteMapping("/{postId}")
 	public ResponseEntity<Void> deletePost(
-		@PathVariable Long postId
+		@PathVariable Long postId,
+		Authentication authentication
 	) {
 		log.info("DELETE /api/v1/posts/{}", postId);
-		postService.deletePost(postId);
+		postService.deletePost(postId, (UserEntity)authentication.getPrincipal());
 		// NO_CONTENT(204, HttpStatus.Series.SUCCESSFUL, "No Content")
 		return ResponseEntity.noContent().build();
 	}

--- a/threads/src/main/java/com/imwoo/threads/exception/user/UserNotAllowedException.java
+++ b/threads/src/main/java/com/imwoo/threads/exception/user/UserNotAllowedException.java
@@ -1,0 +1,13 @@
+package com.imwoo.threads.exception.user;
+
+import org.springframework.http.HttpStatus;
+
+import com.imwoo.threads.exception.ClientErrorException;
+
+public class UserNotAllowedException extends ClientErrorException {
+
+	public UserNotAllowedException() {
+		super(HttpStatus.FORBIDDEN, "User Not Allowed");
+	}
+
+}

--- a/threads/src/main/java/com/imwoo/threads/model/entity/PostEntity.java
+++ b/threads/src/main/java/com/imwoo/threads/model/entity/PostEntity.java
@@ -9,9 +9,14 @@ import org.springframework.data.annotation.LastModifiedDate;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
@@ -21,7 +26,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "post")
+@Table(name = "post"
+	, indexes = {@Index(name = "post_userid_idx", columnList = "userId")})
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -52,6 +58,11 @@ public class PostEntity {
 
 	@Column
 	private ZonedDateTime deletedDateTime;
+
+	// 실제 해당 객체를 조회해야 하는 경우에만 조회 하도록 선언
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "userId", foreignKey = @ForeignKey(name = "fk_post_to_user"))
+	private UserEntity user;
 
 	@PrePersist
 	private void prePersist() {

--- a/threads/src/main/java/com/imwoo/threads/model/entity/PostEntity.java
+++ b/threads/src/main/java/com/imwoo/threads/model/entity/PostEntity.java
@@ -64,6 +64,13 @@ public class PostEntity {
 	@JoinColumn(name = "userId", foreignKey = @ForeignKey(name = "fk_post_to_user"))
 	private UserEntity user;
 
+	public static PostEntity of(String body, UserEntity user) {
+		PostEntity post = new PostEntity();
+		post.body = body;
+		post.user = user;
+		return post;
+	}
+
 	@PrePersist
 	private void prePersist() {
 		this.createdDateTime = ZonedDateTime.now();

--- a/threads/src/main/java/com/imwoo/threads/model/entity/UserEntity.java
+++ b/threads/src/main/java/com/imwoo/threads/model/entity/UserEntity.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
@@ -30,7 +31,8 @@ import lombok.NoArgsConstructor;
  * 그 이유는 postgreSQL 에서는 user 라는 예약어가 존재한다.
  * 예약어를 사용하는 것이 아닌 user 라는 단어를 사용한다는 것은 인식하기 위해 적용
  */
-@Table(name = "\"user\"")
+@Table(name = "\"user\"",
+	indexes = {@Index(name = "user_username_idx", columnList = "username", unique = true)})
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/threads/src/main/java/com/imwoo/threads/model/post/response/PostResponse.java
+++ b/threads/src/main/java/com/imwoo/threads/model/post/response/PostResponse.java
@@ -4,11 +4,13 @@ import java.time.ZonedDateTime;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.imwoo.threads.model.entity.PostEntity;
+import com.imwoo.threads.model.user.User;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record PostResponse(
 	Long postId,
 	String body,
+	User user,
 	ZonedDateTime createdDateTime,
 	ZonedDateTime updatedDateTime,
 	ZonedDateTime deletedDateTime
@@ -18,6 +20,7 @@ public record PostResponse(
 		return new PostResponse(
 			postEntity.getPostId(),
 			postEntity.getBody(),
+			User.from(postEntity.getUser()),
 			postEntity.getCreatedDateTime(),
 			postEntity.getUpdatedDateTime(),
 			postEntity.getDeletedDateTime()

--- a/threads/src/main/java/com/imwoo/threads/repository/PostEntityRepository.java
+++ b/threads/src/main/java/com/imwoo/threads/repository/PostEntityRepository.java
@@ -1,14 +1,8 @@
 package com.imwoo.threads.repository;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.imwoo.threads.model.entity.PostEntity;
-import com.imwoo.threads.model.post.response.PostResponse;
 
 public interface PostEntityRepository extends JpaRepository<PostEntity, Long> {
-
-	List<PostResponse> findAllPostResponseBy();
-
 }

--- a/threads/src/main/java/com/imwoo/threads/service/PostService.java
+++ b/threads/src/main/java/com/imwoo/threads/service/PostService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import com.imwoo.threads.exception.post.PostCreatedFailureException;
 import com.imwoo.threads.exception.post.PostNotFoundException;
 import com.imwoo.threads.model.entity.PostEntity;
+import com.imwoo.threads.model.entity.UserEntity;
 import com.imwoo.threads.model.post.request.PostCreateRequest;
 import com.imwoo.threads.model.post.request.PostUpdateRequest;
 import com.imwoo.threads.model.post.response.PostResponse;
@@ -33,11 +34,9 @@ public class PostService {
 	}
 
 	// 생성
-	public PostResponse createPost(PostCreateRequest postCreateRequest) {
+	public PostResponse createPost(PostCreateRequest postCreateRequest, UserEntity userEntity) {
 		try {
-			var postEntity = new PostEntity();
-			postEntity.setBody(postCreateRequest.body());
-
+			var postEntity = PostEntity.of(postCreateRequest.body(), userEntity);
 			postEntityRepository.save(postEntity);
 
 			return PostResponse.from(postEntity);

--- a/threads/src/test/java/com/imwoo/threads/common/context/support/WithMockAdminSecurityContextFactory.java
+++ b/threads/src/test/java/com/imwoo/threads/common/context/support/WithMockAdminSecurityContextFactory.java
@@ -1,5 +1,6 @@
 package com.imwoo.threads.common.context.support;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -7,10 +8,11 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
 
 import com.imwoo.threads.common.context.support.annotation.WithMockAdmin;
+import com.imwoo.threads.model.entity.UserEntity;
 
 final public class WithMockAdminSecurityContextFactory implements WithSecurityContextFactory<WithMockAdmin> {
 
@@ -20,10 +22,13 @@ final public class WithMockAdminSecurityContextFactory implements WithSecurityCo
 	@Override
 	public SecurityContext createSecurityContext(WithMockAdmin withMockAdmin) {
 		SecurityContext context = SecurityContextHolder.createEmptyContext();
-		User principal = new User(withMockAdmin.username(), withMockAdmin.password(), true, true, true, true,
-			List.of(new SimpleGrantedAuthority(withMockAdmin.roles()[0])));
-		Authentication authentication = UsernamePasswordAuthenticationToken.authenticated(principal,
-			principal.getPassword(), principal.getAuthorities());
+		// User principal = new User(withMockAdmin.username(), withMockAdmin.password(), true, true, true, true,
+		// 	List.of(new SimpleGrantedAuthority(withMockAdmin.roles()[0])));
+		// Custom UserDetails ( UserEntity ) return
+		UserDetails userDetails = new UserEntity(1L, withMockAdmin.username(), withMockAdmin.password(), null, null,
+			ZonedDateTime.now(), ZonedDateTime.now(), null);
+		Authentication authentication = UsernamePasswordAuthenticationToken.authenticated(userDetails,
+			null, List.of(new SimpleGrantedAuthority(withMockAdmin.roles()[0])));
 		context.setAuthentication(authentication);
 		return context;
 	}

--- a/threads/src/test/java/com/imwoo/threads/controller/PostControllerTest.java
+++ b/threads/src/test/java/com/imwoo/threads/controller/PostControllerTest.java
@@ -171,7 +171,7 @@ class PostControllerTest {
 		var url = "/api/v1/posts/";
 
 		// mocking
-		Mockito.when(postService.updatePost(anyLong(), any()))
+		Mockito.when(postService.updatePost(anyLong(), any(), any()))
 			.thenReturn(new PostResponse(1L, "test", null, ZonedDateTime.now(), ZonedDateTime.now(), null));
 
 		// when
@@ -183,9 +183,8 @@ class PostControllerTest {
 		).andExpect(MockMvcResultMatchers.status().isOk());
 
 		// then
-		Mockito.verify(postService, Mockito.times(1)).updatePost(anyLong(), Mockito.any());
-		Mockito.verify(postService, Mockito.only()).updatePost(anyLong(), Mockito.any());
-		Mockito.verify(postService, Mockito.timeout(3000)).updatePost(anyLong(), Mockito.any());
+		Mockito.verify(postService, Mockito.only()).updatePost(anyLong(), Mockito.any(), Mockito.any());
+		Mockito.verify(postService, Mockito.timeout(3000)).updatePost(anyLong(), Mockito.any(), Mockito.any());
 	}
 
 	@Test
@@ -197,7 +196,7 @@ class PostControllerTest {
 		var url = "/api/v1/posts/";
 
 		// mocking
-		Mockito.when(postService.updatePost(anyLong(), any()))
+		Mockito.when(postService.updatePost(anyLong(), any(), any()))
 			.thenThrow(new PostNotFoundException());
 
 		// when
@@ -212,9 +211,8 @@ class PostControllerTest {
 			});
 
 		// then
-		Mockito.verify(postService, Mockito.times(1)).updatePost(anyLong(), Mockito.any());
-		Mockito.verify(postService, Mockito.only()).updatePost(anyLong(), Mockito.any());
-		Mockito.verify(postService, Mockito.timeout(3000)).updatePost(anyLong(), Mockito.any());
+		Mockito.verify(postService, Mockito.only()).updatePost(anyLong(), Mockito.any(), any());
+		Mockito.verify(postService, Mockito.timeout(3000)).updatePost(anyLong(), Mockito.any(), any());
 	}
 
 	@Test
@@ -227,20 +225,20 @@ class PostControllerTest {
 		// mocking
 		Mockito.doNothing()
 			.when(postService)
-			.deletePost(anyLong());
+			.deletePost(anyLong(), any());
 
 		// when
 		mockMvc.perform(
 				MockMvcRequestBuilders.delete(url + anyLong())
 					.contentType(CONTENT_TYPE_JSON)
 					.characterEncoding(CHARSET_UTF8)
+					.content(anyString())
 			).andDo(print())
 			.andExpect(MockMvcResultMatchers.status().isNoContent());
 
 		// then
-		Mockito.verify(postService, Mockito.times(1)).deletePost(anyLong());
-		Mockito.verify(postService, Mockito.only()).deletePost(anyLong());
-		Mockito.verify(postService, Mockito.timeout(3000)).deletePost(anyLong());
+		Mockito.verify(postService, Mockito.only()).deletePost(anyLong(), any());
+		Mockito.verify(postService, Mockito.timeout(3000)).deletePost(anyLong(), any());
 	}
 
 	@Test
@@ -253,22 +251,22 @@ class PostControllerTest {
 		// mocking
 		Mockito.doThrow(new PostNotFoundException())
 			.when(postService)
-			.deletePost(anyLong());
+			.deletePost(anyLong(), any());
 
 		// when
 		mockMvc.perform(
 				MockMvcRequestBuilders.delete(url + anyLong())
 					.contentType(CONTENT_TYPE_JSON)
 					.characterEncoding(CHARSET_UTF8)
+					.content(anyString())
 			).andDo(print())
 			.andExpect(result -> {
 				Assertions.assertInstanceOf(PostNotFoundException.class, result.getResolvedException());
 			});
 
 		// then
-		Mockito.verify(postService, Mockito.times(1)).deletePost(anyLong());
-		Mockito.verify(postService, Mockito.only()).deletePost(anyLong());
-		Mockito.verify(postService, Mockito.timeout(3000)).deletePost(anyLong());
+		Mockito.verify(postService, Mockito.only()).deletePost(anyLong(), any());
+		Mockito.verify(postService, Mockito.timeout(3000)).deletePost(anyLong(), any());
 	}
 
 	@Test

--- a/threads/src/test/java/com/imwoo/threads/controller/PostControllerTest.java
+++ b/threads/src/test/java/com/imwoo/threads/controller/PostControllerTest.java
@@ -18,6 +18,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -28,9 +30,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.imwoo.threads.common.context.support.annotation.WithMockAdmin;
 import com.imwoo.threads.config.TestWebSecurityConfiguration;
 import com.imwoo.threads.exception.post.PostNotFoundException;
+import com.imwoo.threads.model.entity.UserEntity;
 import com.imwoo.threads.model.post.request.PostCreateRequest;
 import com.imwoo.threads.model.post.request.PostUpdateRequest;
 import com.imwoo.threads.model.post.response.PostResponse;
+import com.imwoo.threads.model.user.User;
 import com.imwoo.threads.service.PostService;
 
 import lombok.extern.slf4j.Slf4j;
@@ -63,12 +67,15 @@ class PostControllerTest {
 		var url = "/api/v1/posts";
 
 		// when
-		mockMvc.perform(MockMvcRequestBuilders.get(url))
+		mockMvc.perform(
+				MockMvcRequestBuilders.get(url)
+					.header(HttpHeaders.AUTHORIZATION, "Bearer {ACCESS_TOKEN}")
+			)
 			.andExpect(MockMvcResultMatchers.status().isOk())
-			.andExpect(MockMvcResultMatchers.content().contentType(CONTENT_TYPE_JSON));
+			.andExpect(MockMvcResultMatchers.content().contentType(CONTENT_TYPE_JSON))
+			.andDo(print());
 
 		// then
-		Mockito.verify(postService, Mockito.times(1)).getPosts();
 		Mockito.verify(postService, Mockito.only()).getPosts();
 		Mockito.verify(postService, Mockito.timeout(3000)).getPosts();
 	}
@@ -82,15 +89,18 @@ class PostControllerTest {
 
 		// mocking
 		Mockito.when(postService.getPostByPostId(anyLong()))
-			.thenReturn(new PostResponse(1L, "test", ZonedDateTime.now(), ZonedDateTime.now(), null));
+			.thenReturn(new PostResponse(1L, "test", null, ZonedDateTime.now(), ZonedDateTime.now(), null));
 
 		// when
-		mockMvc.perform(MockMvcRequestBuilders.get(url))
+		mockMvc.perform(
+				MockMvcRequestBuilders.get(url)
+					.header(HttpHeaders.AUTHORIZATION, "Bearer {ACCESS_TOKEN}")
+			)
 			.andExpect(MockMvcResultMatchers.status().isOk())
-			.andExpect(MockMvcResultMatchers.content().contentType(CONTENT_TYPE_JSON));
+			.andExpect(MockMvcResultMatchers.content().contentType(CONTENT_TYPE_JSON))
+			.andDo(print());
 
 		// then
-		Mockito.verify(postService, Mockito.times(1)).getPostByPostId(anyLong());
 		Mockito.verify(postService, Mockito.only()).getPostByPostId(anyLong());
 		Mockito.verify(postService, Mockito.timeout(3000)).getPostByPostId(anyLong());
 	}
@@ -102,23 +112,26 @@ class PostControllerTest {
 		// given
 		var requestBody = readJson(new PostCreateRequest("신규 포스트 생성 테스트 데이터"));
 		var url = "/api/v1/posts";
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		var user = User.from((UserEntity)authentication.getPrincipal());
 
 		// mocking
-		Mockito.when(postService.createPost(any()))
-			.thenReturn(new PostResponse(1L, "test", ZonedDateTime.now(), ZonedDateTime.now(), null));
+		Mockito.when(postService.createPost(any(), any()))
+			.thenReturn(new PostResponse(1L, "test", user, ZonedDateTime.now(), ZonedDateTime.now(), null));
 
 		// when
 		mockMvc.perform(
-			MockMvcRequestBuilders.post(url)
-				.contentType(CONTENT_TYPE_JSON)
-				.characterEncoding(CHARSET_UTF8)
-				.content(requestBody)
-		).andExpect(MockMvcResultMatchers.status().isOk());
+				MockMvcRequestBuilders.post(url)
+					.header(HttpHeaders.AUTHORIZATION, "Bearer {ACCESS_TOKEN}")
+					.contentType(CONTENT_TYPE_JSON)
+					.characterEncoding(CHARSET_UTF8)
+					.content(requestBody)
+			).andExpect(MockMvcResultMatchers.status().isOk())
+			.andDo(print());
 
 		// then
-		Mockito.verify(postService, Mockito.times(1)).createPost(Mockito.any());
-		Mockito.verify(postService, Mockito.only()).createPost(Mockito.any());
-		Mockito.verify(postService, Mockito.timeout(3000)).createPost(Mockito.any());
+		Mockito.verify(postService, Mockito.only()).createPost(Mockito.any(), Mockito.any());
+		Mockito.verify(postService, Mockito.timeout(3000)).createPost(Mockito.any(), Mockito.any());
 	}
 
 	@Test
@@ -130,23 +143,23 @@ class PostControllerTest {
 		var url = "/api/v1/posts";
 
 		// mocking
-		Mockito.when(postService.createPost(any()))
+		Mockito.when(postService.createPost(any(), any()))
 			.thenThrow(new PostNotFoundException());
 
 		// when
 		mockMvc.perform(
 			MockMvcRequestBuilders.post(url)
+				.header(HttpHeaders.AUTHORIZATION, "Bearer {ACCESS_TOKEN}")
 				.contentType(CONTENT_TYPE_JSON)
 				.characterEncoding(CHARSET_UTF8)
 				.content(requestBody)
 		).andExpect(result -> {
 			Assertions.assertInstanceOf(PostNotFoundException.class, result.getResolvedException());
-		});
+		}).andDo(print());
 
 		// then
-		Mockito.verify(postService, Mockito.times(1)).createPost(Mockito.any());
-		Mockito.verify(postService, Mockito.only()).createPost(Mockito.any());
-		Mockito.verify(postService, Mockito.timeout(3000)).createPost(Mockito.any());
+		Mockito.verify(postService, Mockito.only()).createPost(Mockito.any(), Mockito.any());
+		Mockito.verify(postService, Mockito.timeout(3000)).createPost(Mockito.any(), Mockito.any());
 	}
 
 	@Test
@@ -159,7 +172,7 @@ class PostControllerTest {
 
 		// mocking
 		Mockito.when(postService.updatePost(anyLong(), any()))
-			.thenReturn(new PostResponse(1L, "test", ZonedDateTime.now(), ZonedDateTime.now(), null));
+			.thenReturn(new PostResponse(1L, "test", null, ZonedDateTime.now(), ZonedDateTime.now(), null));
 
 		// when
 		mockMvc.perform(

--- a/threads/src/test/java/com/imwoo/threads/service/PostServiceTest.java
+++ b/threads/src/test/java/com/imwoo/threads/service/PostServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.imwoo.threads.exception.post.PostCreatedFailureException;
 import com.imwoo.threads.exception.post.PostNotFoundException;
 import com.imwoo.threads.model.entity.PostEntity;
+import com.imwoo.threads.model.entity.UserEntity;
 import com.imwoo.threads.model.post.request.PostCreateRequest;
 import com.imwoo.threads.model.post.request.PostUpdateRequest;
 import com.imwoo.threads.model.post.response.PostResponse;
@@ -47,7 +48,6 @@ class PostServiceTest {
 		var posts = postService.getPosts();
 
 		// then
-		verify(postEntityRepository, times(1)).findAllPostResponseBy();
 		verify(postEntityRepository, only()).findAllPostResponseBy();
 		verify(postEntityRepository, timeout(3000)).findAllPostResponseBy();
 
@@ -68,7 +68,6 @@ class PostServiceTest {
 		PostResponse post = postService.getPostByPostId(postId);
 
 		// then
-		verify(postEntityRepository, times(1)).findById(anyLong());
 		verify(postEntityRepository, only()).findById(anyLong());
 		verify(postEntityRepository, timeout(3000)).findById(anyLong());
 
@@ -90,7 +89,6 @@ class PostServiceTest {
 		assertThatThrownBy(() -> postService.getPostByPostId(anyLong()))
 			.isInstanceOf(PostNotFoundException.class);
 
-		verify(postEntityRepository, times(1)).findById(anyLong());
 		verify(postEntityRepository, only()).findById(anyLong());
 		verify(postEntityRepository, timeout(3000)).findById(anyLong());
 
@@ -102,19 +100,20 @@ class PostServiceTest {
 	void newCreatePostServiceTestSuccess() {
 		// given
 		var body = "new created post test body";
-		var postEntity = new PostEntity();
+		var userEntity = new UserEntity(1L, "admin", "admin", null, null, ZonedDateTime.now(), ZonedDateTime.now(),
+			null);
+		var postEntity = PostEntity.of(body, userEntity);
 
 		// mocking
 		when(postEntityRepository.save(any(PostEntity.class))).thenReturn(postEntity);
 
 		// when
-		var newPost = postService.createPost(new PostCreateRequest(body));
+		var newPost = postService.createPost(new PostCreateRequest(body), userEntity);
 
 		// then
 		assertThat(newPost).isNotNull();
 		assertThat(newPost.body()).isEqualTo(body);
 
-		verify(postEntityRepository, times(1)).save(any(PostEntity.class));
 		verify(postEntityRepository, only()).save(any(PostEntity.class));
 		verify(postEntityRepository, timeout(3000)).save(any(PostEntity.class));
 
@@ -134,10 +133,9 @@ class PostServiceTest {
 		// when
 
 		// then
-		assertThatThrownBy(() -> postService.createPost(new PostCreateRequest(body)))
+		assertThatThrownBy(() -> postService.createPost(new PostCreateRequest(body), null))
 			.isInstanceOf(PostCreatedFailureException.class);
 
-		verify(postEntityRepository, times(1)).save(any(PostEntity.class));
 		verify(postEntityRepository, only()).save(any(PostEntity.class));
 		verify(postEntityRepository, timeout(3000)).save(any(PostEntity.class));
 

--- a/threads/src/test/java/com/imwoo/threads/service/PostServiceTest.java
+++ b/threads/src/test/java/com/imwoo/threads/service/PostServiceTest.java
@@ -151,7 +151,7 @@ class PostServiceTest {
 		// given
 		var body = "modified post test body";
 		Optional<PostEntity> mockTestPost = Optional.of(
-			new PostEntity(null, body, ZonedDateTime.now(), ZonedDateTime.now(), null));
+			new PostEntity(null, body, ZonedDateTime.now(), ZonedDateTime.now(), null, null));
 
 		// mocking
 		when(postEntityRepository.findById(anyLong())).thenReturn(mockTestPost);
@@ -203,7 +203,7 @@ class PostServiceTest {
 		// given
 		var deleteDateTime = ZonedDateTime.now();
 		Optional<PostEntity> findPostEntity = Optional.of(
-			new PostEntity(null, null, ZonedDateTime.now(), ZonedDateTime.now(), null));
+			new PostEntity(null, null, ZonedDateTime.now(), ZonedDateTime.now(), null, null));
 
 		// mocking
 		when(postEntityRepository.findById(anyLong())).thenReturn(findPostEntity);


### PR DESCRIPTION
# Post, User 연관관계 매핑

## Post / User N : 1 매핑
- Post 객체 안에 UserEntity 품기
  ```java
	  @ManyToOne(fetch = FetchType.LAZY)
	  @JoinColumn(name = "userId", foreignKey = @ForeignKey(name = "fk_post_to_user"))
	  private UserEntity user;
  ```
## Post / User Index 
### Post
- "post_userid_idx" : column ( userId )
  ```  java
  @Table(name = "post"
	  , indexes = {@Index(name = "post_userid_idx", columnList = "userId")})
  ```
### User
- "user_username_idx" : column ( username )
  ```java
  @Table(name = "\"user\"",
	  indexes = {@Index(name = "user_username_idx", columnList = "username", unique = true)})
  ```

### 참고
- PostgreSQL 은 PK 기반으로 클러스터링 인덱스를 생성해주기는 하지만, 초기에만 정렬이 되고 이후에는 정렬되지 않는다.
- 이는 MySQL 이 PK 를 기반으로 클러스터링 인덱스를 만들고 관리하는 방법에 차이가 있다.

## Post, User 연관관계 테스트 케이스 작성
- 인증 객체에 따른 Post Update, Delete 분기