### PR TITLE
feat : User API 구현

### DIFF
--- a/threads/src/main/java/com/imwoo/threads/controller/UserController.java
+++ b/threads/src/main/java/com/imwoo/threads/controller/UserController.java
@@ -3,7 +3,9 @@ package com.imwoo.threads.controller;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,10 +13,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.imwoo.threads.model.entity.UserEntity;
+import com.imwoo.threads.model.post.response.PostResponse;
 import com.imwoo.threads.model.user.User;
 import com.imwoo.threads.model.user.request.UserAuthenticateRequest;
 import com.imwoo.threads.model.user.request.UserSignUpRequest;
+import com.imwoo.threads.model.user.request.UserUpdateRequest;
 import com.imwoo.threads.model.user.response.UserAuthenticationResponse;
+import com.imwoo.threads.service.PostService;
 import com.imwoo.threads.service.UserService;
 
 import jakarta.validation.Valid;
@@ -26,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 
 	private final UserService userService;
+	private final PostService postService;
 
 	@PostMapping
 	public ResponseEntity<User> signUp(@Valid @RequestBody UserSignUpRequest userSignUpRequest) {
@@ -60,5 +67,23 @@ public class UserController {
 		@PathVariable String username
 	) {
 		return ResponseEntity.ok(userService.getUser(username));
+	}
+
+	@PatchMapping("/{username}")
+	public ResponseEntity<User> updateUser(
+		@PathVariable String username,
+		@RequestBody UserUpdateRequest userUpdateRequest,
+		Authentication authentication
+	) {
+		var user = userService.updateUser(username, userUpdateRequest, (UserEntity)authentication.getPrincipal());
+		return ResponseEntity.ok(user);
+	}
+
+	// GET /users/{username}/posts
+	@GetMapping("/{username}/posts")
+	public ResponseEntity<List<PostResponse>> getPostsByUsername(
+		@PathVariable String username
+	) {
+		return ResponseEntity.ok(postService.getPostsByUsername(username));
 	}
 }

--- a/threads/src/main/java/com/imwoo/threads/controller/UserController.java
+++ b/threads/src/main/java/com/imwoo/threads/controller/UserController.java
@@ -1,9 +1,14 @@
 package com.imwoo.threads.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.imwoo.threads.model.user.User;
@@ -40,5 +45,20 @@ public class UserController {
 			userAuthenticateRequest.password()
 		);
 		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping
+	public ResponseEntity<List<User>> getUsers(
+		@RequestParam(required = false) String query
+	) {
+		var users = userService.getUsers(query);
+		return ResponseEntity.ok(users);
+	}
+
+	@GetMapping("/{username}")
+	public ResponseEntity<User> getUser(
+		@PathVariable String username
+	) {
+		return ResponseEntity.ok(userService.getUser(username));
 	}
 }

--- a/threads/src/main/java/com/imwoo/threads/model/entity/UserEntity.java
+++ b/threads/src/main/java/com/imwoo/threads/model/entity/UserEntity.java
@@ -37,7 +37,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-@SQLDelete(sql = "update users set deletedDateTime = CURRENT_TIMESTAMP where userId = ?")
+@SQLDelete(sql = "update user set deletedDateTime = CURRENT_TIMESTAMP where userId = ?")
 //@Where(clause = "deletedDateTime IS NULL")
 @SQLRestriction("deletedDateTime IS NULL")
 /**

--- a/threads/src/main/java/com/imwoo/threads/model/user/request/UserUpdateRequest.java
+++ b/threads/src/main/java/com/imwoo/threads/model/user/request/UserUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.imwoo.threads.model.user.request;
+
+public record UserUpdateRequest(String description) {
+}

--- a/threads/src/main/java/com/imwoo/threads/repository/PostEntityRepository.java
+++ b/threads/src/main/java/com/imwoo/threads/repository/PostEntityRepository.java
@@ -1,8 +1,13 @@
 package com.imwoo.threads.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.imwoo.threads.model.entity.PostEntity;
+import com.imwoo.threads.model.entity.UserEntity;
 
 public interface PostEntityRepository extends JpaRepository<PostEntity, Long> {
+
+	List<PostEntity> findByUser(UserEntity user);
 }

--- a/threads/src/main/java/com/imwoo/threads/repository/UserEntityRepository.java
+++ b/threads/src/main/java/com/imwoo/threads/repository/UserEntityRepository.java
@@ -1,5 +1,6 @@
 package com.imwoo.threads.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,9 @@ import com.imwoo.threads.model.entity.UserEntity;
 
 @Repository
 public interface UserEntityRepository extends JpaRepository<UserEntity, Long> {
+
+	// Containing : %param%
+	List<UserEntity> findByUsernameContaining(String username);
 
 	Optional<UserEntity> findByUsername(String username);
 }

--- a/threads/src/main/java/com/imwoo/threads/service/PostService.java
+++ b/threads/src/main/java/com/imwoo/threads/service/PostService.java
@@ -7,12 +7,14 @@ import org.springframework.stereotype.Service;
 import com.imwoo.threads.exception.post.PostCreatedFailureException;
 import com.imwoo.threads.exception.post.PostNotFoundException;
 import com.imwoo.threads.exception.user.UserNotAllowedException;
+import com.imwoo.threads.exception.user.UserNotFoundException;
 import com.imwoo.threads.model.entity.PostEntity;
 import com.imwoo.threads.model.entity.UserEntity;
 import com.imwoo.threads.model.post.request.PostCreateRequest;
 import com.imwoo.threads.model.post.request.PostUpdateRequest;
 import com.imwoo.threads.model.post.response.PostResponse;
 import com.imwoo.threads.repository.PostEntityRepository;
+import com.imwoo.threads.repository.UserEntityRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 public class PostService {
 
 	private final PostEntityRepository postEntityRepository;
+	private final UserEntityRepository userEntityRepository;
 
 	// 전체 조회
 	// TODO 페이지 처리 필요
@@ -82,5 +85,17 @@ public class PostService {
 	private PostEntity getPostByPostIdWithThrow(Long postId) {
 		return postEntityRepository.findById(postId)
 			.orElseThrow(() -> new PostNotFoundException(postId));
+	}
+
+	public List<PostResponse> getPostsByUsername(String username) {
+		var userEntity = userEntityRepository.findByUsername(username)
+			.orElseThrow(() -> new UserNotFoundException(username));
+
+		var posts = postEntityRepository.findByUser(userEntity);
+
+		return posts
+			.stream()
+			.map(PostResponse::from)
+			.toList();
 	}
 }

--- a/threads/src/main/java/com/imwoo/threads/service/UserService.java
+++ b/threads/src/main/java/com/imwoo/threads/service/UserService.java
@@ -1,5 +1,7 @@
 package com.imwoo.threads.service;
 
+import java.util.List;
+
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -59,5 +61,30 @@ public class UserService implements UserDetailsService {
 			// TODO : 패스워드 불일치 시 고려할 사항을 차후 적용해보기. 일단은 단순 일치 정보자 없다고 제공
 			throw new UserNotFoundException(username);
 		}
+	}
+
+	public List<User> getUsers(String query) {
+		List<UserEntity> userEntities;
+
+		if (query != null && !query.isBlank()) {
+			// TODO : query 검색어 기반, 해당 검색하기 username 에 포함되는 유저목록 가져오기.
+			// 쿼리 Like 예약어로 간단한 검색은 가능하지만 차후 elasticsearch 기반 엔진을 사용해서 좀더 검색에 용이한 방식으로 구현해보기
+			userEntities = userEntityRepository.findByUsernameContaining(query);
+		} else {
+			// 전체 유저 검색
+			userEntities = userEntityRepository.findAll();
+		}
+
+		return userEntities
+			.stream()
+			.map(User::from)
+			.toList();
+	}
+
+	public User getUser(String username) {
+		var userEntity = userEntityRepository.findByUsername(username)
+			.orElseThrow(() -> new UserNotFoundException(username));
+
+		return User.from(userEntity);
 	}
 }

--- a/threads/src/test/java/com/imwoo/threads/controller/UserControllerTest.java
+++ b/threads/src/test/java/com/imwoo/threads/controller/UserControllerTest.java
@@ -1,9 +1,11 @@
 package com.imwoo.threads.controller;
 
 import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.imwoo.threads.common.context.support.annotation.WithMockAdmin;
 import com.imwoo.threads.config.TestWebSecurityConfiguration;
 import com.imwoo.threads.exception.user.UserDuplicatedException;
 import com.imwoo.threads.exception.user.UserNotFoundException;
@@ -217,4 +220,85 @@ class UserControllerTest {
 		Mockito.verify(userService, Mockito.only()).authenticate(anyString(), anyString());
 		Mockito.verify(userService, Mockito.timeout(3000)).authenticate(anyString(), anyString());
 	}
+
+	@Test
+	@DisplayName("[Success] 회원 조회 전체 요청 테스트")
+	@WithMockAdmin
+	void userSearchQueryNotExistsRequestTestSuccess() throws Exception {
+		// given
+		var url = "/api/v1/users";
+		var users = List.of(
+			User.from(
+				new UserEntity(1L, "admin", "admin", null, null, ZonedDateTime.now(), ZonedDateTime.now(), null)),
+			User.from(
+				new UserEntity(2L, "a", "admin", null, null, ZonedDateTime.now(), ZonedDateTime.now(), null))
+		);
+
+		// mocking
+		when(userService.getUsers(anyString())).thenReturn(users);
+
+		// when
+		mockMvc.perform(
+				MockMvcRequestBuilders.get(url)
+			).andExpect(MockMvcResultMatchers.status().isOk())
+			.andDo(print());
+
+		// then
+		Mockito.verify(userService, Mockito.times(1)).getUsers(null);
+		Mockito.verify(userService, Mockito.only()).getUsers(null);
+	}
+
+	@Test
+	@DisplayName("[Success] 회원 조회 Like 요청 테스트")
+	@WithMockAdmin
+	void userSearchQueryExistsRequestTestSuccess() throws Exception {
+		// given
+		var query = "a";
+		var url = "/api/v1/users";
+		var users = List.of(
+			User.from(
+				new UserEntity(1L, "admin", "admin", null, null, ZonedDateTime.now(), ZonedDateTime.now(), null)),
+			User.from(
+				new UserEntity(2L, "a", "admin", null, null, ZonedDateTime.now(), ZonedDateTime.now(), null))
+		);
+
+		// mocking
+		when(userService.getUsers(anyString())).thenReturn(users);
+
+		// when
+		mockMvc.perform(
+				MockMvcRequestBuilders.get(url)
+					.param("query", query)
+			).andExpect(MockMvcResultMatchers.status().isOk())
+			.andDo(print());
+
+		// then
+		Mockito.verify(userService, Mockito.times(1)).getUsers(anyString());
+		Mockito.verify(userService, Mockito.only()).getUsers(anyString());
+	}
+
+	@Test
+	@DisplayName("[Success] 회원 조회 단건 요청 테스트")
+	@WithMockAdmin
+	void userSearchUsernameRequestTestSuccess() throws Exception {
+		// given
+		var username = "admin";
+		var url = "/api/v1/users/";
+		var user = User.from(
+			new UserEntity(1L, "admin", "admin", null, null, ZonedDateTime.now(), ZonedDateTime.now(), null));
+
+		// mocking
+		when(userService.getUser(anyString())).thenReturn(user);
+
+		// when
+		mockMvc.perform(
+				MockMvcRequestBuilders.get(url + username)
+			).andExpect(MockMvcResultMatchers.status().isOk())
+			.andDo(print());
+
+		// then
+		Mockito.verify(userService, Mockito.times(1)).getUser(anyString());
+		Mockito.verify(userService, Mockito.only()).getUser(anyString());
+	}
+
 }

--- a/threads/src/test/java/com/imwoo/threads/service/UserServiceTest.java
+++ b/threads/src/test/java/com/imwoo/threads/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
@@ -216,5 +217,88 @@ class UserServiceTest {
 
 		verifyNoMoreInteractions(userEntityRepository);
 
+	}
+
+	@Test
+	@DisplayName("[Success] User 조회 전체 서비스 테스트")
+	void userSearchQueryNotExistsServiceTestSuccess() {
+		// given
+
+		// mocking
+		Mockito.when(userEntityRepository.findAll()).thenReturn(List.of(new UserEntity()));
+
+		// when
+		userService.getUsers(null);
+
+		// then
+		verify(userEntityRepository, times(1)).findAll();
+		verify(userEntityRepository, only()).findAll();
+		verify(userEntityRepository, timeout(3000)).findAll();
+
+		verifyNoMoreInteractions(userEntityRepository);
+	}
+
+	@Test
+	@DisplayName("[Success] User 조회 Like 서비스 테스트")
+	void userSearchQueryExistsServiceTestSuccess() {
+		// given
+		var query = "a";
+
+		// mocking
+		Mockito.when(userEntityRepository.findByUsernameContaining(anyString())).thenReturn(List.of(new UserEntity()));
+
+		// when
+		userService.getUsers(query);
+
+		// then
+		verify(userEntityRepository, times(1)).findByUsernameContaining(anyString());
+		verify(userEntityRepository, only()).findByUsernameContaining(anyString());
+		verify(userEntityRepository, timeout(3000)).findByUsernameContaining(anyString());
+
+		verifyNoMoreInteractions(userEntityRepository);
+	}
+
+	@Test
+	@DisplayName("[Success] User 조회 단건 서비스 테스트")
+	void userSearchUsernameServiceTestSuccess() {
+		// given
+		var username = "admin";
+
+		// mocking
+		Mockito.when(userEntityRepository.findByUsername(anyString()))
+			.thenReturn(Optional.of(
+				new UserEntity(1L, username, "admin", null, null, ZonedDateTime.now(), ZonedDateTime.now(), null)));
+
+		// when
+		userService.getUser(username);
+
+		// then
+		verify(userEntityRepository, times(1)).findByUsername(anyString());
+		verify(userEntityRepository, only()).findByUsername(anyString());
+		verify(userEntityRepository, timeout(3000)).findByUsername(anyString());
+
+		verifyNoMoreInteractions(userEntityRepository);
+	}
+
+	@Test
+	@DisplayName("[Failure] User 조회 단건 서비스 테스트")
+	void userSearchUsernameServiceTestFailure() {
+		// given
+		var username = "admin";
+
+		// mocking
+		Mockito.when(userEntityRepository.findByUsername(anyString()))
+			.thenReturn(Optional.empty());
+
+		// when
+		Assertions.assertThatThrownBy(() -> userService.getUser(username))
+			.isInstanceOf(UserNotFoundException.class);
+
+		// then
+		verify(userEntityRepository, times(1)).findByUsername(anyString());
+		verify(userEntityRepository, only()).findByUsername(anyString());
+		verify(userEntityRepository, timeout(3000)).findByUsername(anyString());
+
+		verifyNoMoreInteractions(userEntityRepository);
 	}
 }


### PR DESCRIPTION
# User API 구현

## User Update ( Description )
- User info Description 수정
 ```java
UserController.java

	@PatchMapping("/{username}")
	public ResponseEntity<User> updateUser(
		@PathVariable String username,
		@RequestBody UserUpdateRequest userUpdateRequest,
		Authentication authentication
	) {
		var user = userService.updateUser(username, userUpdateRequest, (UserEntity)authentication.getPrincipal());
		return ResponseEntity.ok(user);
	}

UserService.java

	public User updateUser(String username, UserUpdateRequest userUpdateRequest, UserEntity currentUserEntity) {
		var userEntity = userEntityRepository.findByUsername(username)
			.orElseThrow(() -> new UserNotFoundException(username));

		// TODO : 동일 사용자만 수정 권한 부여
		if (!currentUserEntity.equals(userEntity)) {
			throw new UserNotAllowedException();
		}

		if (userUpdateRequest.description() != null) {
			// TODO 트랜잭션 사용해서 JPA 영속성 컨텍스트의 더티 체킹 활용 해보기. / 현재는 Merge 방식으로 적용
			userEntity.setDescription(userUpdateRequest.description());
			userEntityRepository.save(userEntity);
		}

		return User.from(userEntity);
	}
  ```

## User Posts 조회
- User 객체를 기반으로 생성한 Posts 전체 조회
 ```java
UserController.java

	@GetMapping("/{username}/posts")
	public ResponseEntity<List<PostResponse>> getPostsByUsername(
		@PathVariable String username
	) {
		return ResponseEntity.ok(postService.getPostsByUsername(username));
	}

PostService.java
	public List<PostResponse> getPostsByUsername(String username) {
		var userEntity = userEntityRepository.findByUsername(username)
			.orElseThrow(() -> new UserNotFoundException(username));

		var posts = postEntityRepository.findByUser(userEntity);

		return posts
			.stream()
			.map(PostResponse::from)
			.toList();
	}
  ```